### PR TITLE
Indices on "_latest" tables

### DIFF
--- a/src/main/scala/repos/Action.scala
+++ b/src/main/scala/repos/Action.scala
@@ -81,6 +81,8 @@ object Action {
 
   case object Min extends AggregationFunction
 
+  case class IndexTableSizeAction[Id, M, R](index: SecondaryIndex[Id, M, R]) extends IndexAction[Id, M, R, Int]
+
   implicit class StreamAction[K, A](val a: Action[Streaming[K], A]) extends AnyVal {
 //    def mapStream[L](f: K => L): Action[Streaming[L], A] = MapStreamAction[K, L, A](a, f)
   }

--- a/src/main/scala/repos/SecondaryIndex.scala
+++ b/src/main/scala/repos/SecondaryIndex.scala
@@ -7,7 +7,7 @@ import scala.language.existentials
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
-case class SecondaryIndex[Id, M, R](repo: Repo[Id, M], name: String, projection: M => Seq[R])(implicit val projectionType : ProjectionType[R])
+case class SecondaryIndex[Id, M, R](repo: Repo[Id, M], name: String, projection: M => Seq[R], isOnLatest: Boolean = false)(implicit val projectionType : ProjectionType[R])
 
 class SecondaryIndexQueries[Id, M, R](val index: SecondaryIndex[Id, M, R]) extends AnyVal {
   import SecondaryIndexQueries._
@@ -33,6 +33,8 @@ class SecondaryIndexQueries[Id, M, R](val index: SecondaryIndex[Id, M, R]) exten
   def max: Action[NoStream, Option[R]] = IndexAggegrationAction(index, Max)
 
   def min: Action[NoStream, Option[R]] = IndexAggegrationAction(index, Min)
+
+  def tableSize: Action[NoStream, Int] = IndexTableSizeAction(index)
 }
 
 object SecondaryIndexQueries {

--- a/src/main/scala/repos/inmem/InMemDb.scala
+++ b/src/main/scala/repos/inmem/InMemDb.scala
@@ -69,6 +69,8 @@ class InMemDb extends Database {
         Future.successful(withInnerIndex(index)(_.aggregate(agg)))
       case IndexCountAction(index, value) =>
         Future.successful(withInnerIndex(index)(_.count(value)))
+      case IndexTableSizeAction(index) =>
+        Future.successful(withInnerIndex(index)(_.tableSize))
     }
   }
 

--- a/src/main/scala/repos/jdbc/JdbcDb.scala
+++ b/src/main/scala/repos/jdbc/JdbcDb.scala
@@ -60,6 +60,13 @@ class JdbcDb(val profile: JdbcProfile, private[repos] val db: JdbcProfile#Backen
           _ <- DBIO.sequence((newEntries zip pkList).toSeq.sortBy(t => idMapper.toUUID(t._1.id)).map {
             e => latestEntryTable.insertOrUpdate((e._1.id, e._1.entry, e._2))
           })
+          // Update any indices on Latest table
+          _ <- DBIO.sequence(effectiveIndexMap.values.filter(_.isOnLatest).toSeq.flatMap { index =>
+            // Each individual insert must be preceded by a delete of old values
+            (elements zip pkList).map { case (e, pk) =>
+              index.buildDeleteAction(Set(e._1)) andThen index.buildInsertAction(Seq(e -> pk))
+            }
+          })
         } yield pkList
         db.run(r.transactionally)
       } else {
@@ -88,7 +95,10 @@ class JdbcDb(val profile: JdbcProfile, private[repos] val db: JdbcProfile#Backen
     def delete(ids: Set[Id])(implicit ec: ExecutionContext): Future[Unit] = {
       db.run(
         entryTable.filter(_.uuid inSet ids).delete andThen
-          latestEntryTable.filter(_.id inSet ids).delete).map(_ => ())
+          latestEntryTable.filter(_.id inSet ids).delete andThen
+          DBIO.sequence(indexMap.values.filter(_.isOnLatest).map(
+            _.indexTable.filter(_.id inSet ids).delete))
+      ).map(_ => ())
     }
 
     def getEntries(fromPk: Long, idsConstraint: Option[Seq[Id]], excludePks: Set[Long],
@@ -129,9 +139,12 @@ class JdbcDb(val profile: JdbcProfile, private[repos] val db: JdbcProfile#Backen
           MappedColumnType.base(e.to, e.from)(e.classTag, baseColumnType(e.base))
       }
 
-      def ix3TableName: String = s"ix3_${index.repo.name}__${index.name}"
-
+      val ix3TableName: String = s"ix3_${index.repo.name}__${index.name}"
+      val isOnLatest: Boolean = index.isOnLatest
       val indexTable = new TableQuery(new Ix3Table[Id, R](_, ix3TableName)(repo.idMapper, repo.idClass, baseColumnType(rp)))
+
+      def buildDeleteAction(ids: Set[Id]) =
+        indexTable.filter(_.id.inSet(ids)).delete
 
       def buildInsertAction(entries: Iterable[((Id, M), Long)]) = {
         indexTable ++= (for {
@@ -153,13 +166,17 @@ class JdbcDb(val profile: JdbcProfile, private[repos] val db: JdbcProfile#Backen
       }
 
       private def idsSatisfying[T <: Rep[_]](sqlFilter: Rep[R] => T)(implicit wt: CanBeQueryCondition[T]) =
-        (for {
+        if (index.isOnLatest)
+          indexTable.withFilter(x => sqlFilter(x.value)).map(_.id)
+        else (for {
           m <- indexTable if sqlFilter(m.value)
           v <- latestEntryTable if (v.id === m.id && v.parentPk === m.parentPk)
         } yield v.id)
 
       private def allIndexedValues =
-        (for {
+        if (index.isOnLatest)
+          indexTable.map(_.value)
+        else (for {
           m <- indexTable
           v <- latestEntryTable if (v.id === m.id && v.parentPk === m.parentPk)
         } yield m.value)
@@ -186,6 +203,8 @@ class JdbcDb(val profile: JdbcProfile, private[repos] val db: JdbcProfile#Backen
         case Max => db.run(allIndexedValues.max.result)
         case Min => db.run(allIndexedValues.min.result)
       }
+
+      def tableSize: Future[Int] = db.run(indexTable.size.result)
     }
   }
 
@@ -302,6 +321,8 @@ class JdbcDb(val profile: JdbcProfile, private[repos] val db: JdbcProfile#Backen
       innerIndex(index).count(criteria)
     case IndexAggegrationAction(index, agg) =>
       innerIndex(index).aggregate(agg)
+    case IndexTableSizeAction(index) =>
+      innerIndex(index).tableSize
   }
 
   private[repos] lazy val jc = new JanitorComponent(profile, db)

--- a/src/test/scala/repos/RepoSpec.scala
+++ b/src/test/scala/repos/RepoSpec.scala
@@ -142,6 +142,28 @@ class RepoSpec extends org.scalatest.fixture.FlatSpec with MustMatchers with Opt
       await(db.run(FooRepo.seqIndex.allMatching('a'))) must be(Seq(id5 -> "ababa"))
   }
 
+  "indexes on _latest tables" should "work" in {
+    db =>
+      val id1 = FooId(UUID.randomUUID)
+      val id2 = FooId(UUID.randomUUID)
+      await(db.run(FooRepo.insert(id1, "1a")))
+      await(db.run(FooRepo.insert(id2, "2a")))
+      await(db.run(FooRepo.insert(id2, "2b")))
+
+      await(db.run(FooRepo.getEntries())).size must be(3)
+      await(db.run(FooRepo.firstCharIndex.tableSize)) must be(3)
+      await(db.run(FooRepo.allLatestEntries())).size must be(2)
+      await(db.run(FooRepo.firstCharIndexLatest.tableSize)) must be(2)
+
+      // This leaves partial index on full table unchanged (legacy behavior),
+      // but removes value from partial index on latest table (new behavior)
+      await(db.run(FooRepo.insert(id2, "")))
+      await(db.run(FooRepo.getEntries())).size must be(4)
+      await(db.run(FooRepo.firstCharIndex.tableSize)) must be(3)
+      await(db.run(FooRepo.allLatestEntries())).size must be(2)
+      await(db.run(FooRepo.firstCharIndexLatest.tableSize)) must be(1)
+  }
+
   "Action.seq" should "work for insert followed by get" in {
     db =>
       val id1 = FooId(UUID.randomUUID())

--- a/src/test/scala/repos/testutils/FooRepo.scala
+++ b/src/test/scala/repos/testutils/FooRepo.scala
@@ -16,6 +16,10 @@ object FooRepo extends Repo[FooId, String]("foo") {
     case t if t.size > 0 => t(0)
   }
 
+  def firstCharIndexLatest = partialIndexTable("first_ch_latest", onLatest = true) {
+    case t if t.size > 0 => t(0)
+  }
+
   def firstTwoIndex = indexTable("first_two_ch")(_.take(2))
 
   def seqIndex = multiIndexTable("seq")(_.toSeq)

--- a/src/test/scala/repos/testutils/TestUtils.scala
+++ b/src/test/scala/repos/testutils/TestUtils.scala
@@ -28,4 +28,12 @@ object TestUtils {
     await(publisher.foreach(s => synchronized { b+=s }))
     b.result()
   }
+
+  def tableSize(jdbcDb: JdbcDb, tableName: String): Int = {
+    val s = jdbcDb.db.source.createConnection.createStatement
+    s.execute(s"select count(*) from $tableName")
+    val rs = s.getResultSet
+    rs.next()
+    rs.getInt(1)
+  }
 }


### PR DESCRIPTION
This commit implements index tables that contain only data extracted from the `_latest` table of a repo, instead of indexing the full historical data and needing to join with `_latest` on each query. This requires deletion of old matching values from the index upon insertion.

This will improve performance of new indexes and in particular will limit the size of "partial indices" by making sure entries no longer matched by the partial function are cleared out when new data is inserted for a given ID. The change is "opt-in" with existing indices remaining unchanged.

Specifics:
- Added an `onLatest` parameter (defaulting to `false`) to `SecondaryIndex` and the APIs that create it.
- Added deletion logic for the new indices in table insertion and deletion methods.
- Added warnings when creating a multi-index or partial index that is _not_ based on a `_latest` table, since such an index will never delete values that are no longer matched.
- Added catch-up logic in `TableJanitor` for the new indices.
- Added optimizations to the retrieval methods that return only the index data, so that index tables they don't join with `_latest` tables for filtering when they're already based on them.
- Added `IndexTableSizeAction` to retrieve the "raw" table size of an index, without joining it with the `_latest` table. This is mostly useful for unit-testing the size of the new indices.

Note: the changes to the `IndexTableMethods` trait and the `SecondaryIndex` case class maintain source compatibility but break binary compatibility.