### PR TITLE
Updating libraries needed to support Play 2.6 and Scala 2.12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: scala
 sudo: false
 scala:
 - 2.11.7
+- 2.12.10
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 # These directories are cached to S3 at the end of the build
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2020-01-02
+### Added
+- Adds scala 2.12 cross building support 
+
+### Changed
+- Upgrades scala-async library from 0.9.5 to 0.9.7
+- Upgrades sbt-twirl plugin dependency from 1.1.1 to 1.3.2
+- Upgrades scalatest 2.2.6 to scalatest 3.1.0
+- Upgrades scalacheck 1.12.5 to 1.14.1 
+- Adds scalactic dependency 3.1.0
+- Adds scalatestplus-scalacheck 3.1.0.0-RC2 dependency

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,16 @@
 import ReleaseTransformations._
 
-val SlickVersion = "3.1.1"
+val SlickVersion = "3.2.3"
 
 val AkkaVersion = "2.5.22"
 
 val AkkaHttpVersion = "10.1.8"
 
-scalaVersion := "2.11.12"
+lazy val scala212 = "2.12.10"
+lazy val scala211 = "2.11.12"
+lazy val supportedScalaVersions = List(scala212, scala211)
+
+scalaVersion := scala211
 
 organization := "com.trueaccord.repos"
 
@@ -36,16 +40,21 @@ libraryDependencies ++= Seq(
     "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
     "com.typesafe.slick" %% "slick" % SlickVersion,
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-    "org.scala-lang.modules" %% "scala-async" % "0.9.5",
+    "org.scala-lang.modules" %% "scala-async" % "0.9.7",
     "org.xerial.snappy" % "snappy-java" % "1.1.1.6",
     "com.github.shyiko" % "mysql-binlog-connector-java" % "0.4.1",
     "org.slf4j" % "slf4j-api" % "1.7.5",
 
     "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "test",
     "com.h2database" % "h2" % "1.4.189" % "test",
-    "org.scalatest" %% "scalatest" % "2.2.6" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
+    "org.scalactic" %% "scalactic" % "3.1.0",
+    "org.scalatest" %% "scalatest" % "3.1.0" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.14.1" % "test",
+    "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % "test"
 )
 
-lazy val root = (project in file(".")).enablePlugins(SbtTwirl)
+lazy val root = (project in file("."))
+  .enablePlugins(SbtTwirl)
+  .settings(crossScalaVersions := supportedScalaVersions)
+
 

--- a/project/twirl.sbt
+++ b/project/twirl.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.1.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.2")

--- a/src/main/scala/repos/jdbc/JdbcDb.scala
+++ b/src/main/scala/repos/jdbc/JdbcDb.scala
@@ -9,9 +9,9 @@ import repos.SecondaryIndex._
 import repos.SecondaryIndexQueries._
 import repos._
 import slick.dbio.Effect.Read
-import slick.driver.JdbcProfile
+import slick.jdbc.JdbcProfile
 import slick.lifted.CanBeQueryCondition
-import slick.profile.FixedSqlStreamingAction
+import slick.sql.FixedSqlStreamingAction
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.{existentials, higherKinds}

--- a/src/main/scala/repos/jdbc/RepoManagement.scala
+++ b/src/main/scala/repos/jdbc/RepoManagement.scala
@@ -6,7 +6,6 @@ import slick.jdbc.meta.MTable
 import scala.collection.parallel.ForkJoinTaskSupport
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
-import scala.concurrent.ExecutionContext.Implicits.global
 
 object RepoManagement {
   def existingTables(jdbcDb: JdbcDb)(implicit ec: ExecutionContext): Set[String] = {
@@ -15,11 +14,9 @@ object RepoManagement {
 
   // Create all missing repos and index tables.
   def createMissingRepos(jdbcDb: JdbcDb,
-                         repos: Seq[Repo[_, _]], log: String => Unit = println): Seq[SecondaryIndex[_, _, _]] = {
+                         repos: Seq[Repo[_, _]], log: String => Unit = println)(implicit ec: ExecutionContext): Seq[SecondaryIndex[_, _, _]] = {
     val jc = jdbcDb.jc
     import jc.profile.api._
-
-    import scala.concurrent.ExecutionContext.Implicits.global
 
     {
       val _tables = existingTables(jdbcDb)
@@ -52,7 +49,7 @@ object RepoManagement {
     parRepos.flatMap(upgradeRepo).seq
   }
 
-  def dropAll(jdbcDb: JdbcDb, repos: Seq[Repo[_, _]]): Unit = {
+  def dropAll(jdbcDb: JdbcDb, repos: Seq[Repo[_, _]])(implicit ec: ExecutionContext): Unit = {
     import jdbcDb.profile.api._
     val existingTablesInternal: Set[String] = existingTables(jdbcDb)
     if (existingTablesInternal.contains(jdbcDb.jc.ScannerCheckpointsTableName)) {

--- a/src/test/scala/repos/EquivalenceSpec.scala
+++ b/src/test/scala/repos/EquivalenceSpec.scala
@@ -3,8 +3,9 @@ package repos
 import java.util.UUID
 
 import org.scalacheck.Gen
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import repos.Action._
 import repos.SecondaryIndexQueries._
 import repos.inmem.InMemDb
@@ -148,7 +149,7 @@ object GenActions {
 }
 
 
-class EquivalenceSpec extends FlatSpec with MustMatchers with PropertyChecks {
+class EquivalenceSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
   val ids: Vector[FooId] = Vector.fill(30)(FooId(UUID.randomUUID()))
 
   def waitAndCompare[T](f1: Future[T], f2: Future[T]) = {

--- a/src/test/scala/repos/jdbc/TableJanitorSpec.scala
+++ b/src/test/scala/repos/jdbc/TableJanitorSpec.scala
@@ -3,13 +3,14 @@ package repos.jdbc
 import java.util.UUID
 
 import org.scalacheck.Gen
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, MustMatchers}
-import repos.testutils.FooId
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import repos.EntryTableRecord
-import repos.jdbc.TableJanitor.{State, Gap}
+import repos.jdbc.TableJanitor.{Gap, State}
+import repos.testutils.FooId
 
-class TableJanitorSpec extends FlatSpec with MustMatchers with PropertyChecks {
+class TableJanitorSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
   def entry(pk: Long, ts: Long): EntryTableRecord[FooId, String] =
     EntryTableRecord(pk, FooId(UUID.randomUUID()), ts, "")
 
@@ -75,7 +76,7 @@ class TableJanitorSpec extends FlatSpec with MustMatchers with PropertyChecks {
   def genScenario = for {
     state <- genState
     items <- Gen.someOf((state.maxSeen + 1L) to (state.maxSeen + 1000L)).map(_.map(entry(_, 101)))
-  } yield (state, items)
+  } yield (state, items.sortBy(_.pk))
 
   def genScenarioNoGaps = for {
     state <- genStateNoGaps

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.16-SNAPSHOT"
+version in ThisBuild := "0.2.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0-SNAPSHOT"
+version in ThisBuild := "0.1.16-SNAPSHOT"


### PR DESCRIPTION
Libraries updated for Play 2.6 integration:
* Slick
* Twirl plugin

Libraries updated for Scala 2.12 integration:
* Scalatest
* Scalacheck
* Scala-async

Where a Repos dependency already had a higher version than the Play 2.6 dependency, I kept the repos version as-is. E.g. the Akka version here was left at 2.5.22, which is higher than the minimum 2.5.3 akka version in Play 2.6

This commit also adds the ability to cross compile with Scala 2.12.

Minor changes to the execution context are included with this commit. Please let me know if these are actually top-level contract changes. 