### PR TITLE
Setting version to 0.2.0.

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.16-SNAPSHOT"
+version in ThisBuild := "0.2.0"


### PR DESCRIPTION
We had previously thought that this project was auto-incremented upon releasing to Maven, (see comment on previous PR here: https://github.com/trueaccord/repos/pull/6#discussion_r365499239,) however, it appears that this project is manually versioned, then released to an artifact repository, and then re-versioned as a snapshot (see commit log for examples: https://github.com/trueaccord/repos/commits/master)

Note: Bumping the minor version was chosen over bumping the patch version because in the time since that the last artifact was built we are additionally supporting Scala 2.12 via cross-building. The change is fully backwards compatible. I'm happy to adjust that versioning scheme if you feel that's the wrong call. 