### PR TITLE
Play2.6 specifies slick column length

### DIFF
--- a/src/main/scala/repos/jdbc/JanitorComponent.scala
+++ b/src/main/scala/repos/jdbc/JanitorComponent.scala
@@ -5,7 +5,7 @@ import repos.Repo
 import scala.async.Async.{ async, await }
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
-import slick.driver.{JdbcDriver, JdbcProfile}
+import slick.jdbc.JdbcProfile
 
 case class IndexStatusRecord(pk: Option[Long] = None, indexTableName: String, lastPk: Long)
 
@@ -20,7 +20,7 @@ class JanitorComponent(val profile: JdbcProfile, db: JdbcProfile#Backend#Databas
   class JanitorIndexStatusTable(tag: Tag) extends Table[IndexStatusRecord](tag, TableJanitor.JANITOR_INDEX_STATUS_TABLE) {
     def pk = column[Long]("pk", O.AutoInc, O.PrimaryKey)
 
-    def indexTableName = column[String]("index_table")
+    def indexTableName = column[String]("index_table", O.Length(254))
 
     def lastPk = column[Long]("last_pk")
 
@@ -50,9 +50,9 @@ class JanitorComponent(val profile: JdbcProfile, db: JdbcProfile#Backend#Databas
   class ScannerCheckpointsTable(tag: Tag) extends Table[ScannerCheckpoint](tag, ScannerCheckpointsTableName) {
     import scala.async.Async.{ async, await }
     /** Identifies the scanning process (there may be more than one process scanning the same repo. */
-    def jobId = column[String]("job_id")
+    def jobId = column[String]("job_id", O.Length(254))
 
-    def repoName = column[String]("repo_name")
+    def repoName = column[String]("repo_name", O.Length(254))
 
     def lastPk = column[Long]("last_pk")
 

--- a/src/main/scala/repos/jdbc/JdbcDb.scala
+++ b/src/main/scala/repos/jdbc/JdbcDb.scala
@@ -234,7 +234,7 @@ class JdbcDb(val profile: JdbcProfile, private[repos] val db: JdbcProfile#Backen
 
     def id = column[Id]("id")(columnMapper[Id])
 
-    def value = column[R]("value")
+    def value = column[R]("value", O.Length(254))
 
     // We build an index on the parentPk to make it efficient to find rows in the log table
     // which are not indexed (we look up this table for a lack of a record with a given pk)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.1"
+version in ThisBuild := "0.2.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.16-SNAPSHOT"
+version in ThisBuild := "0.2.1"


### PR DESCRIPTION
Specifying the column lengths is necessary to support mysql string-like columns (varchar, text, etc) with this version of slick. 

Patch version is bumped manually per our pending repository publication discussion.  